### PR TITLE
fix: OBS connect with version 32.0 new path and file type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valorant-autorecord",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "",
   "main": "build/index.js",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ import path from 'node:path'
 import Mustache from 'mustache'
 import fetch from 'node-fetch'
 import {run} from './util/run.js'
-import ini from 'ini'
 
 // @ts-ignore
 Mustache.escape! = v => v
@@ -121,23 +120,23 @@ async function main() {
             if(config.obs.connection !== undefined) return config.obs.connection
 
             // Otherwise, try to get them from the OBS config file
-            const obsConfigPath = path.join(process.env['APPDATA']!, 'obs-studio', 'global.ini')
+            const obsConfigPath = path.join(process.env['APPDATA']!, 'obs-studio', 'plugin_config', 'obs-websocket', 'config.json')
             try {
-                const obsConfig = ini.parse(await fs.readFile(obsConfigPath, 'utf-8'))
-                const obsWebsocketConfig = obsConfig['OBSWebSocket'] as {
-                    ServerEnabled: boolean
-                    ServerPort: string
-                    ServerPassword: string
+                const obsConfig = JSON.parse(await fs.readFile(obsConfigPath, 'utf-8'))
+                const obsWebsocketConfig = obsConfig as {
+                    server_enabled: boolean
+                    server_port: string
+                    server_password: string
                 }
 
-                if(!obsWebsocketConfig.ServerEnabled) {
+                if(!obsWebsocketConfig.server_enabled) {
                     console.log('\n⚠️ OBS WebSocket server is not enabled!\n\n\tTo enable it, go to Tools > WebSockets Server Settings\n\tand check "Enable WebSocket server" then click "OK"\n')
                 }
 
                 return {
                     ip: '127.0.0.1',
-                    port: parseInt(obsWebsocketConfig.ServerPort),
-                    password: obsWebsocketConfig.ServerPassword
+                    port: parseInt(obsWebsocketConfig.server_port),
+                    password: obsWebsocketConfig.server_password
                 }
             } catch(e) {
                 throw new Error(`Failed to get OBS connection settings from ${obsConfigPath}, error: ${e}`)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
         /* Language and Environment */
-        "target": "ES2017",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+        "target": "ES2018",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
         // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
         // "jsx": "preserve",                                /* Specify what JSX code is generated. */
         // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
Changed the new path to the WebSocket settings, and now gets the correct keys from the json file.
Rest of the program worked still fine.